### PR TITLE
Fix TypeScript complaining about default import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import {PluginFunction} from 'vue';
+
 export interface Announcer
 {
     data: Record<string, any>;
@@ -12,3 +14,10 @@ declare module 'vue/types/vue'
         $announcer: Announcer;
     }
 }
+
+declare class VueAnnouncer
+{
+    static install: PluginFunction<never>;
+}
+
+export default VueAnnouncer;


### PR DESCRIPTION
Fixed a mistake I made in the previous pr where I didn't notify TypeScript of the install function so it can be used in 'Vue.use'.

Sorry about that, should've caught it before.