### PR TITLE
Vue Force Next Tick

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "standard-version": "^4.3.0",
     "surge": "^0.21.3",
     "vue": "^2.5.16",
+    "vue-force-next-tick" : "^1.0.3",
     "vue-template-compiler": "^2.5.16"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,17 @@
 import VueAnnouncer from './vue-announcer.vue'
+import VueForceNextTick from 'vue-force-next-tick'
 import { OPTIONS } from './constants'
 
 export default function install (Vue, options = {}, router = null) {
   options = {...OPTIONS, ...options}
 
+  Vue.use(VueForceNextTick);
   Vue.component('VueAnnouncer', VueAnnouncer)
   Vue.prototype.$announcer = {
     set (message) {
       if (this.data) {
         this.data.content = ''
-        Vue.nextTick()
-          .then(() => {
+        Vue.$forceNextTick(() => {
             this.data.content = message
           })
       }


### PR DESCRIPTION
Hey, first off, sorry if this doesn't work. I am only able to make edits through gitlab on the computer I am using right now. 

I discovered a bug where I announce the same message twice. The message is set to '' before it is re-set to the initial message but nextTick is not enough to get the aria-live section to recognize the change of text.

I found some other reporting of this issue as well as a package to resolve it. 
https://github.com/vuejs/vue/issues/9200
https://www.npmjs.com/package/vue-force-next-tick

I haven't tested this at all so I don't know if this is the solution, but I think it might be. 

Anywho, hope this helps and thank you for the work you do!
