### PR TITLE
Add Support for Inertia Router to Automatically Announce Page Titles on Navigation

### DIFF
--- a/src/components/Announcer.vue
+++ b/src/components/Announcer.vue
@@ -22,25 +22,38 @@ export default defineComponent({
     const { announce } = useAnnouncer()
 
     if (data.value.router) {
-      data.value.router.afterEach((to: any) => {
-        const announcer = ref<VueAnnouncerMeta>({...to.meta.announcer} || {})
-        if (announcer.value.skip || !isClient) return
+      if ('afterEach' in data.value.router) {
+        data.value.router.afterEach((to: any) => {
+          const announcer = ref<VueAnnouncerMeta>({...to.meta.announcer} || {})
+          if (announcer.value.skip || !isClient) return
 
-        setTimeout(() => {
-          draf(() => {
-            const msg = (announcer.value.message || document.title).trim()
-            const complement = (announcer.value.routeComplement || data.value.routeComplement).trim()
-            const politeness = announcer.value.politeness || null
-            announce(`${msg} ${complement}`, politeness)
-          })
-        }, 500)
-      })
+          setTimeout(() => {
+            draf(() => {
+              const msg = (announcer.value.message || document.title).trim()
+              const complement = (announcer.value.routeComplement || data.value.routeComplement).trim()
+              const politeness = announcer.value.politeness || null
+              announce(`${msg} ${complement}`, politeness)
+            })
+          }, 500)
+        })
+      } elseif ('on' in data.value.router) {
+        data.value.router.on('navigate', () => {
+          if (!isClient) return
+
+          setTimeout(() => {
+            draf(() => {
+              const msg = document.title.trim()
+              const complement = data.value.routeComplement.trim()
+              announce(`${msg} ${complement}`)
+            })
+          }, 500)
+        })
+      }
     }
 
     return { data }
   }
 })
-
 </script>
 
 <style scoped>


### PR DESCRIPTION
This pull request introduces a new feature that enables the [Inertia.js router](https://inertiajs.com/events#navigate) to automatically announce page titles during navigation, similar to how vue-router operates with vue-announcer.

The changes primarily involve modifications to `Announcer.vue`, where we now check if the router object has an 'afterEach' method (indicative of vue-router) or an 'on' method (indicative of Inertia router). Depending on the method available, the router will announce the page title on each navigation event.

Here's a usage example with Inertia:

```javascript
import { createApp } from 'vue'
import App from './App.vue'
import { router } from '@inertiajs/vue3'
import VueAnnouncer from '@vue-a11y/announcer'
import '@vue-a11y/announcer/dist/index.css'

createApp(App)
  .use(VueAnnouncer, { router })
  .mount('#app')
// Page title is announced automatically
```

I'm not sure how to better implement this feature with Inertia...
Looking forward to your feedback.